### PR TITLE
Fixing memory leaks issues

### DIFF
--- a/src/trace.c
+++ b/src/trace.c
@@ -159,7 +159,18 @@ void
 hashtable_delete (hashtable_t *ht)
 {
   for (size_t i = 0; i < ht->size; i++)
-    free (ht->buckets[i]);
+    {
+      if (ht->buckets[i])
+        {
+          size_t j = 0;
+          while (ht->buckets[i][j])
+            {
+              instr_delete (ht->buckets[i][j]);
+              j++;
+            }
+        }
+      free (ht->buckets[i]);
+    }
   free (ht);
 }
 
@@ -191,7 +202,7 @@ hashtable_insert (hashtable_t * ht, instr_t * instr)
   size_t k = 0;
   while (ht->buckets[index][k] != NULL)
     if (ht->buckets[index][k++]->address == instr->address)
-      return true;
+      return false; /* No error but we need to delete the redundant one */
 
   instr_t **new_bucket = calloc (k + 2, sizeof (instr_t *));
   if (!new_bucket)

--- a/src/tracker.c
+++ b/src/tracker.c
@@ -322,7 +322,9 @@ main (int argc, char *argv[], char *envp[])
 	  /* Create the instr_t structure */
 	  instr_t *instr = instr_new (ip, insn[0].size, buf);
 	  if (!instr)
-	    err (EXIT_FAILURE, "error:");
+	    err (EXIT_FAILURE, "error: cannot create instruction");
+
+    cs_free (insn, count);
 
 	  if (!hashtable_insert (ht, instr))
 	    instr_delete (instr);
@@ -338,7 +340,9 @@ main (int argc, char *argv[], char *envp[])
       while (ptrace(PTRACE_SINGLESTEP, child, NULL, NULL));
     }
 
-  fprintf(output,
+  cs_close (&handle);
+
+  fprintf (output,
 	  "\n"
 	  "\tStatistics about this run\n"
 	  "\t=========================\n"
@@ -350,6 +354,8 @@ main (int argc, char *argv[], char *envp[])
 	  (size_t) DEFAULT_HASHTABLE_SIZE, hashtable_collisions (ht));
 
   hashtable_delete (ht);
+
+
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The program had memory leaks due to :
- memory allocated by the Capstone API but never freed
- redundant instruction never freed when already in the hashtable
- hashtable_delete only freeing the bucket itself and not the elements
in it
- output file not being close